### PR TITLE
Update data-collector template to use Docker strategy

### DIFF
--- a/data-collector-template.yaml
+++ b/data-collector-template.yaml
@@ -99,13 +99,8 @@ objects:
         ref: master
         uri: https://github.com/tumido/aiops-data-collector
     strategy:
-      sourceStrategy:
-        from:
-          kind: ImageStreamTag
-          name: python:3.6
-          namespace: openshift
-      type: Source
-      incremental: true
+      dockerStrategy: {}
+      type: Docker
     triggers:
     - type: Generic
       generic:


### PR DESCRIPTION
Just change the build strategy from s2i to Docker.

Related: https://github.com/ManageIQ/aiops-data-collector/pull/1