### PR TITLE
Make the Kafka server template param a thing

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,5 @@ from one endpoint to another service.
 ❯ oc new-app --template aiops-data-collector --param AI_MICROSERVICE_HOST=dummy-ai-service:8080
 ❯ oc new-app --template aiops-publisher
 ```
+
+Optionally, the `KAFKA_SERVER` parameter can be specified for `aiops-incoming-listener` and `aiops-publisher` within the `oc new-app` command.

--- a/incoming-listener-template.yaml
+++ b/incoming-listener-template.yaml
@@ -2,6 +2,11 @@ kind: Template
 apiVersion: v1
 metadata:
   name: aiops-incoming-listener
+parameters:
+  - name: KAFKA_SERVER
+    value: platform-mq-cluster-kafka.platform-mq.svc:9092
+    description: Kafka server and port
+
 objects:
 
 - kind: Service
@@ -42,7 +47,7 @@ objects:
         containers:
         - env:
           - name: KAFKA_SERVER
-            value: platform-mq-cluster-kafka.platform-mq.svc:9092
+            value: "${KAFKA_SERVER}"
           - name: KAFKA_TOPIC
             value: available
           - name: NEXT_MICROSERVICE_HOST

--- a/publisher-template.yaml
+++ b/publisher-template.yaml
@@ -3,9 +3,10 @@ apiVersion: v1
 metadata:
   name: aiops-publisher
 parameters:
-  - description: Kafka server and port
-    name: KAFKA_SERVER
-    required: true
+  - name: KAFKA_SERVER
+    value: platform-mq-cluster-kafka.platform-mq.svc:9092
+    description: Kafka server and port
+
 objects:
 
 - kind: Service


### PR DESCRIPTION
Update OpenShift templates to consume a param `KAFKA_SERVER` allowing to specify the server when new app in OpenShift is being created.

Param is optional with default value to prod Insights message bus.

Replaces: #2 