### PR TITLE
Rewrite README to be cooler with badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,27 @@
-# AI-Ops pipeline
+# AI-Ops: Dummy AI microservice
 
-OpenShift deployment scheme for the AI-Ops pipeline
+[![Build Status](https://travis-ci.org/ManageIQ/aiops-dummy-ai-service.svg?branch=master)](https://travis-ci.org/ManageIQ/aiops-dummy-ai-service)
+[![License](https://img.shields.io/badge/license-APACHE2-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
 
-The pipeline is designed to be orchestrated within OpenShift. Some microservices are expected to be interchangeble at some point in the future.
-
-## Templates
-
-| Name                      | Filename                          | Purpose                                                | Repository |
-| ------------------------- | --------------------------------- | ------------------------------------------------------ | ---------- |
-| aiops-globals             | `globals-template.yaml`           | Secrets store for AWS credentials                      |            |
-| aiops-incoming-listener   | `incoming-listener-template.yaml` | Kafka listener service, S2I image                      | [ManageIQ/aiops-incoming-listener](https://github.com/ManageIQ/aiops-incoming-listener) |
-| aiops-data-collector      | `data-collector-template.yaml`    | Data collector service with public route, Docker image | [ManageIQ/aiops-data-collector](https://github.com/ManageIQ/aiops-data-collector) |
-| aiops-publisher           | `publisher-template.yaml`         | Kafka publisher with S3 uploading service, S2I image   | [ManageIQ/aiops-publisher](https://github.com/ManageIQ/aiops-publisher) |
-
-## Dummy AI service
-
-This repo is a home for the `dummy-ai-service`. This is a simple Python web server service. **It does no AI!**.
-The service is intended for debugging purposes only as an AI microservice placeholder. This dummy AI just forwards the data
+This is a simple Python web server service. **It does no AI!**. The service is intended for debugging purposes only as an AI microservice placeholder. This dummy AI just forwards the data
 from one endpoint to another service.
+
+
+## Get Started
+
+* Learn about other services within our pipeline
+  - [incoming-listener](https://github.com/ManageIQ/aiops-incoming-listener)
+  - [data-collector](https://github.com/ManageIQ/aiops-data-collector)
+  - [publisher](https://github.com/ManageIQ/aiops-publisher)
+* Discover all AI services we're integrating with
+  - [dummy-ai](https://github.com/ManageIQ/aiops-dummy-ai-service)
+  - [aicoe-insights-clustering](https://github.com/RedHatInsights/aicoe-insights-clustering)
+* See deployment templates in the [e2e-deploy](https://github.com/RedHatInsights/e2e-deploy) repository
+
+## Configure
+
+* `NEXT_MICROSERVICE_HOST` - where to pass the processed data (`hostname:port`)
+
+## License
+
+See [LICENSE](LICENSE)


### PR DESCRIPTION
Unify `README.md` across all AI-Ops pipeline repos. Don't list confusing info anymore and point to `e2e-deploy` for templates.