### PR TITLE
Make the `ai_service` name in the json payload configurable to the env APP_NAME

### DIFF
--- a/server.py
+++ b/server.py
@@ -14,6 +14,8 @@ def create_application():
     app = Flask(__name__)
     app.config['NEXT_MICROSERVICE_HOST'] = \
         os.environ.get('NEXT_MICROSERVICE_HOST')
+    app.config['AI_SERVICE'] = \
+        os.environ.get('AI_SERVICE')
 
     return app
 
@@ -28,6 +30,7 @@ ROOT_LOGGER.addHandler(default_handler)
 def index():
     """Pass data to next endpoint."""
     next_service = APP.config['NEXT_MICROSERVICE_HOST']
+    ai_service = APP.config['AI_SERVICE']
     try:
         input_data = request.get_json(force=True, cache=False)
 
@@ -52,6 +55,7 @@ def index():
     volume_type_validation_worker(
         input_data,
         next_service,
+        ai_service,
         b64_identity
     )
 

--- a/workers.py
+++ b/workers.py
@@ -50,6 +50,7 @@ def _retryable(method: str, *args, **kwargs) -> requests.Response:
 def volume_type_validation_worker(
         job: dict,
         next_service: str,
+        ai_service: str,
         b64_identity: str = None
 ) -> Thread:
     """Validate Volume Types."""
@@ -96,7 +97,7 @@ def volume_type_validation_worker(
         # Build response JSON
         output = {
             'id': batch_id,
-            'ai_service': 'ai_volumetype_validation',
+            'ai_service': ai_service,
             'data': result.to_dict()
         }
 


### PR DESCRIPTION
The change here eventually leads to the results being published on this topic -

```
platform.upload.aiops-volume-type-validation
```

(as opposed to `platform.upload.ai_volumetype_validation`)

This will be very useful towards keeping the listener topic in the Consumer service generic.

Related: https://github.com/ManageIQ/aiops-publisher/pull/19