### PR TITLE
Idle cost and instance cost savings combined

### DIFF
--- a/idle_cost_savings/idle_cost_savings.py
+++ b/idle_cost_savings/idle_cost_savings.py
@@ -741,12 +741,15 @@ class AwsIdleCostSavings:   #noqa  #Too few public methods
         message = {
             "message": "We can use bigger instance types, which can lead to "
                        "cost reduction.",
+            "cluster_name":
+                self.sources[(self.sources['id'] == source_id)].name.values[0],
             "availability_zone": zone,
             "instance_type": instance_type,
             "recommended_nodes_for_shut_down": {
                 "nodes": self._format_node_list(
-                    nodes, "instance_type_cost_savings").to_dict('records')
-            },
+                        nodes, "instance_type_cost_savings"
+                    ).to_dict('records')
+                },
             "recommended_new_instance_types": formated_recommendations
         }
         self.result.add_recommendations(

--- a/idle_cost_savings/idle_cost_savings.py
+++ b/idle_cost_savings/idle_cost_savings.py
@@ -735,7 +735,10 @@ class AwsIdleCostSavings:   #noqa  #Too few public methods
                 'message': "{} nodes with instance type '{}' can be replaced"
                            " with {} nodes with instance type '{}'.".format(
                                 nodes_count, instance_type, key, value
-                            )
+                            ),
+                'affected_nodes_count': nodes_count,
+                'from_instance_type': instance_type,
+                'to_instance_type': value
             })
 
         message = {

--- a/idle_cost_savings/idle_cost_savings.py
+++ b/idle_cost_savings/idle_cost_savings.py
@@ -537,6 +537,7 @@ class AwsIdleCostSavings:   #noqa  #Too few public methods
 
         if self._utilization(container_nodes_group, container_nodes_group,
                              containers) >= self.min_utilization:
+            self.result.add_recommendations(source_id, 'idle_cost_savings', {})
             return
 
         shut_off_nodes = []
@@ -696,6 +697,10 @@ class AwsIdleCostSavings:   #noqa  #Too few public methods
 
         if len(recommendations) == 0:
             self.logger.debug("No applicable combination found to recommend.")
+            self.result.add_recommendations(
+                source_id,
+                'instance_type_cost_savings', {}
+            )
             return
 
         formated_recommendations = []

--- a/idle_cost_savings/idle_cost_savings.py
+++ b/idle_cost_savings/idle_cost_savings.py
@@ -505,6 +505,28 @@ class AwsIdleCostSavings:   #noqa  #Too few public methods
             container_nodes_group,
             active_containers
     ):
+        """Cost savings recommendations."""
+        containers = \
+            active_containers[
+                active_containers["container_node_id"].isin(
+                    container_nodes_group['id']
+                )
+            ]
+
+        self._recommend_idle_cost_savings(
+            source_id, container_nodes_group, containers
+        )
+
+        self._recommend_instance_type_cost_savings(
+            source_id, container_nodes_group
+        )
+
+    def _recommend_idle_cost_savings(
+            self,
+            source_id,
+            container_nodes_group,
+            active_containers
+    ):
         """Recommend nodes that can be shutoff."""
         containers = \
             active_containers[


### PR DESCRIPTION
Enhanced the original Idle Cost Savings implementation by adding Instance Type Cost Savings

The core logic here has been adopted from the gitlab code.

Since one use case (or one pipeline) is responsible for generating 2 kinds of recommendations for `Idle Cost Savings` and `Instance Type Cost Savings`, the recommendations in the per-host info would also contain an array `applicable_rules` which will be a listing of rules the recommendations are applicable to.

The `recommendations` dict could have any of the following possible structures -

```
"recommendations": {

}
```

```
"recommendations": {
  "cluster_id": <cluster_id>,
  "idle_cost_savings_details": {...},
  "instance_type_cost_savings_details": {...},
  "applicable_rules": [
    aiops_instance_type_cost_savings",
    aiops_idle_cost_savings"
  ]
}
```

```
"recommendations": {
  "cluster_id": <cluster_id>,
  "idle_cost_savings_details": {...},
  "applicable_rules": [
    aiops_idle_cost_savings"
  ]
}
```

```
"recommendations": {
  "cluster_id": <cluster_id>,
  "instance_type_cost_savings_details": {...},
  "applicable_rules": [
    aiops_instance_type_cost_savings"
  ]
}
```







