### PR TITLE
Improving logging readability

### DIFF
--- a/server.py
+++ b/server.py
@@ -2,7 +2,6 @@ import logging
 import os
 
 from flask import Flask, jsonify, request
-from flask.logging import default_handler
 from werkzeug.exceptions import BadRequest
 
 from prometheus_metrics import generate_aggregated_metrics
@@ -23,9 +22,7 @@ def create_application():
 
 
 APP = create_application()
-ROOT_LOGGER = logging.getLogger()
-ROOT_LOGGER.setLevel(APP.logger.level)
-ROOT_LOGGER.addHandler(default_handler)
+APP.logger = logging.getLogger('server')
 
 
 @APP.route("/", methods=['POST', 'PUT'])

--- a/wsgi.py
+++ b/wsgi.py
@@ -4,8 +4,11 @@ import sys
 
 from gunicorn.arbiter import Arbiter
 
-# Sync logging between Flask and Gunicorn
-logging.getLogger().setLevel(logging.INFO)
+logging.basicConfig(
+    level=logging.DEBUG,
+    format='%(asctime)s | p-%(process)d | t-%(thread)d | %(name)s |'
+           ' %(levelname)-5s | %(message)s'
+)
 gunicorn_logger = logging.getLogger('gunicorn.error')
 
 # all gunicorn processes in a given instance need to access a common
@@ -24,9 +27,6 @@ except IOError as e:
         "Error while creating prometheus_multiproc_dir: %s", e
     )
     sys.exit(Arbiter.APP_LOAD_ERROR)
-
-APP.logger.handlers = gunicorn_logger.handlers
-APP.logger.setLevel(gunicorn_logger.level)
 
 # Export "application" variable to gunicorn
 # pylama:ignore=C0103


### PR DESCRIPTION
This is to improve the readability by using some build-it python logging features.
Eliminating duplicated log lines due to duplicated handlers.

##Before

```
2019-05-31 17:24:30,127 | worker | #102 | DEBUG | Thread-3: Worker started
[2019-05-31 17:24:30 +0000] [34] [INFO] Job started
[2019-05-31 17:24:30,127] DEBUG in workers: Thread-3: Worker started
2019-05-31 17:24:30,127 | index | #59 | INFO | Job started
[2019-05-31 17:24:30,127] INFO in server: Job started
2019-05-31 17:24:30,128 | worker | #121 | INFO | Thread-3: Job account ID 1460290 (batch ID: f2c61a7c-83c8-11e9-8128-0a580a8007ed): Started...
[2019-05-31 17:24:30,128] INFO in workers: Thread-3: Job account ID 1460290 (batch ID: f2c61a7c-83c8-11e9-8128-0a580a8007ed): Started...
...
2019-05-31 18:09:17,014 | worker | #143 | INFO | Analysis have 1287 rows in scores
[2019-05-31 18:09:17,014] INFO in workers: Analysis have 1287 rows in scores
2019-05-31 18:09:17,015 | worker | #161 | INFO | Thread-4: Job ID 6b226ac0-83ce-11e9-a7b5-0a580a8007ed: detection done, publishing to http://aiops-publisher:8080/api/v0/publish  ...
[2019-05-31 18:09:17,015] INFO in workers: Thread-4: Job ID 6b226ac0-83ce-11e9-a7b5-0a580a8007ed: detection done, publishing to http://aiops-publisher:8080/api/v0/publish  ...
```

##After
```
2019-05-31 17:18:42,227 | p-34 | t-140242570123008 | worker | DEBUG | Worker started
2019-05-31 17:18:42,227 | p-34 | t-140242311968512 | server | INFO  | Job started
2019-05-31 17:18:42,229 | p-34 | t-140242570123008 | worker | INFO  | Job account ID 1460290 (batch ID: 2368eae8-83c8-11e9-83a0-0a580a830870): Started...
...
2019-05-31 17:20:56,027 | p-34 | t-140242570123008 | worker | INFO  | Analysis have 1287 rows in scores
2019-05-31 17:20:56,027 | p-34 | t-140242570123008 | worker | INFO  | Job ID 2368eae8-83c8-11e9-83a0-0a580a830870: detection done, publishing to http://aiops-publisher:8080/api/v0/publish  ...
 ```

